### PR TITLE
Enable Render deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const app = express();
-const port = 3000;
+// Use the PORT environment variable if provided (e.g. Render)
+const port = process.env.PORT || 3000;
 
 const dataFile = path.join(__dirname, 'data.json');
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "bank-database",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -6,7 +6,8 @@ const bodyParser = require('body-parser');
 const fs = require('fs');
 const path = require('path');
 const app = express();
-const port = 3000;
+// Use the PORT environment variable if available (e.g. on Render)
+const port = process.env.PORT || 3000;
 
 const DATA_FILE = path.join(__dirname, 'data.json');
 


### PR DESCRIPTION
## Summary
- Read server port from `process.env.PORT` to support Render
- Add `npm start` script targeting `server.js`
- Ignore `node_modules/` to keep repository clean

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a427d8bb9c832eb127d74359588a4f