### PR TITLE
feat: add initial MCP server

### DIFF
--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -1,0 +1,52 @@
+import { Server } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+
+// Create MCP server instance
+const server = new Server({
+  name: 'bank-api-mcp',
+  version: '1.0.0',
+});
+
+// Tool: get record by credit card number
+server.tool({
+  name: 'getRecordByCard',
+  description: 'Get customer record by credit card number',
+  inputSchema: z.object({
+    cardNumber: z.string(),
+  }),
+  outputSchema: z.object({
+    record: z.any(),
+  }),
+  execute: async ({ cardNumber }) => {
+    const response = await fetch(`http://localhost:3000/api/data/card/${encodeURIComponent(cardNumber)}`);
+    if (!response.ok) {
+      throw new Error(`API responded with status ${response.status}`);
+    }
+    const record = await response.json();
+    return { record };
+  },
+});
+
+// Tool: create support ticket
+server.tool({
+  name: 'createTicket',
+  description: 'Create a support ticket',
+  inputSchema: z.object({
+    description: z.string(),
+  }),
+  outputSchema: z.object({ id: z.string() }),
+  execute: async ({ description }) => {
+    const response = await fetch('http://localhost:3000/api/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description }),
+    });
+    if (!response.ok) {
+      throw new Error(`API responded with status ${response.status}`);
+    }
+    return response.json();
+  },
+});
+
+// Start listening for MCP connections
+server.listen();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "mcp": "node mcp-server.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -12,6 +13,8 @@
   "description": "",
   "dependencies": {
     "body-parser": "^2.2.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "@modelcontextprotocol/server": "^0.1.0",
+    "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
## Summary
- add new MCP server exposing tools for card lookup and ticket creation
- include MCP script and dependencies

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run mcp` (fails: Cannot find package '@modelcontextprotocol/server')

------
https://chatgpt.com/codex/tasks/task_e_68ac7e2a2f68832e8cf0d1c710ad5d64